### PR TITLE
Support for external script file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 sine.c
 obj
 bin
+out.wav

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Principle of operation
 ----------------------
 
 The library runs as a state machine.  Synthesis is performed completely
-using only integer artihmatic operations: specifically addition,
+using only integer arithmetic operations: specifically addition,
 subtraction, left and right shifts, and occasional multiplication.  This
 makes it suitable for smaller CPU cores such as Atmel's TinyAVR, ARM's
 Cortex M0+, lower-end TI MSP430 and other minimalist CPU cores that lack
@@ -51,7 +51,7 @@ waveform moves through the following states:
    state of multiple voices to be configured at some convenient point in
    the program in bulk whilst still providing flexibility on when a
    particular note is played.  As there is no amplitude change, an
-   "infinte" time delay may also be specified here, allowing a note to
+   "infinite" time delay may also be specified here, allowing a note to
    be configured then triggered "on cue".
 
 2. Attack phase: The amplitude starts at 0, and using an approximated
@@ -287,7 +287,7 @@ amplitude.
 ### PC port (`pc`)
 
 This uses `libao` and a command line interface to simulate the output of
-the synthesizer.  It was used to debug the synthesizer.
+the synthesizer and to output a `.wav` file.  It was used to debug the synthesizer.
 
 The synthesizer commands are given as command-line arguments:
 
@@ -321,8 +321,11 @@ The synthesizer commands are given as command-line arguments:
   `A`
 * `reset` resets the ADSR state machine for the selected channel.
 
+Or, alternatively, you can pass all the above commands stored in a text file:
+* `-- NAME` loads and run the script, and skip all the remaining arguments.
+
 Once the `enable` bit-mask is set, the program loops, playing sound via
-`libao` and writing the samples to `out.raw` for later analysis until
+`libao` and writing the samples to `out.wav` for later analysis until
 all bits in the `enable` bit-mask are cleared by the ADSR state machines.
 
-When the program runs out of command line arguments, it exits.
+When the program runs out of command line arguments, or the script ends, it exits.

--- a/ports/pc/main.c
+++ b/ports/pc/main.c
@@ -29,8 +29,12 @@ struct voice_ch_t poly_voice[16];
 struct poly_synth_t synth;
 
 /* Read a script instead of command-line tokens */
-static void readScript(const char* name, int* argc, char*** argv) {
+static int readScript(const char* name, int* argc, char*** argv) {
 	FILE *fp = fopen(name, "r");
+	if (!fp) {
+		fprintf(stderr, "Failed to open script file: %s\n", name);
+		return 0;
+	}
    	char token[64];
 	int n = 0;
 	int size = 16;
@@ -45,6 +49,7 @@ static void readScript(const char* name, int* argc, char*** argv) {
 
 	*argv = list;
 	*argc = n;
+	return 1;
 }
 
 int main(int argc, char** argv) {
@@ -90,7 +95,9 @@ int main(int argc, char** argv) {
 		if (!strcmp(argv[0], "--")) {
 			const char* name = argv[1];
 			_DPRINTF("reading script %s\n", name);
-			readScript(name, &argc, &argv);
+			if (!readScript(name, &argc, &argv)) {
+				return 1;
+			}
 			// Fake item will be skipped at the end of the if
 			argc++;
 			argv--;

--- a/ports/pc/test
+++ b/ports/pc/test
@@ -1,0 +1,3 @@
+voice 0 scale 100 delay 1 attack 100 decay 100 sustain 1000 release 10 peak 63 samp 32 triangle 2000 63 
+voice 1 scale 100 delay 1 attack 100 decay 100 sustain 50 release 1000 peak 63 samp 32 sawtooth 1500 63
+en 3


### PR DESCRIPTION
Hello,
This PR contains some enhancement to allow running the `pc` port more in a scripted way.

All the arguments supported by the command-line can be put in a script file (white-space separated), and fed to the application via -- followed by the script file name.

In addition, in order to run on headless systems, the `pc` app allow to run without a sound-card. Since the `libao` supports outputting to file too, I removed the manual `.raw` support in favor of the more portable `.wav` file with few line of code changes.

Thanks for the great library. Working to extend it with a tiny serial-line optimized sequencer!
